### PR TITLE
Update outdated dependencies.

### DIFF
--- a/models/deck.js
+++ b/models/deck.js
@@ -6,7 +6,7 @@
  *
  */
 
- const fullDeck = require("./data/cards.json");
+const fullDeck = require("./data/cards.json");
 
 module.exports = {
 	/**

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "koa-router": "^5.3.0",
     "koa-socket": "^4.4.0",
     "koa-static-folder": "^0.1.6",
-    "radium": "^0.17.1",
+    "radium": "^0.18.1",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "redis": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^3.0.0",
     "istanbul": "^0.4.4",
     "mocha": "^3.2.0",
-    "shipit-cli": "^1.4.1",
+    "shipit-cli": "^2.0.0",
     "shipit-deploy": "^2.1.2",
     "watchify": "^3.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "event-emitter": "^0.3.4",
     "koa": "^1.1.2",
     "koa-bodyparser": "^2.0.1",
-    "koa-hbs": "^0.7.0",
+    "koa-hbs": "^0.9.0",
     "koa-router": "^5.3.0",
     "koa-socket": "^4.4.0",
     "koa-static-folder": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babelify": "^7.3.0",
-    "browserify": "^13.0.1",
+    "browserify": "^14.1.0",
     "chai": "^3.5.0",
     "eslint": "^3.0.0",
     "istanbul": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.0.0",
     "istanbul": "^0.4.4",
-    "mocha": "^2.5.3",
+    "mocha": "^3.2.0",
     "shipit-cli": "^1.4.1",
     "shipit-deploy": "^2.1.2",
     "watchify": "^3.7.0"


### PR DESCRIPTION
I recognise this isn't officially maintained at the moment, but I thought I'd just put this up since I opened the original issue.

I haven't actually tested `shipit` deployment yet; waiting to get a few spare hours to learn it and see if "deploying" to a local Docker image adequately kicks the tires. Other updates *appear* to have no negative effects on project artefacts.

For whatever it's worth.

[Closes #57]